### PR TITLE
Add another catch for AB genotypes

### DIFF
--- a/src/sw_filt.py
+++ b/src/sw_filt.py
@@ -140,6 +140,8 @@ for x in nonempty_genotype_files:
 		first_line = f.readline().strip()
 		if 'BB' in first_line:
 			plink_AB_command()
+                elif 'B' in first_line:
+                        plink_AB_command()
 		elif 'C' in first_line: 
 			sys.exit('Genotypes are not in AB or 12 format.')
 		elif 'T' in first_line: 


### PR DESCRIPTION
Previously only caught genotypes not separated by spaces by finding "BB" updated to look for just "B" too.